### PR TITLE
Use alternative port for postgres container

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ stages:
       alias: db
     - name: postgrest/postgrest
       alias: server
-    - name: gitlab.cosmian.com:5000/core/kms:2.3.0_ci
+    - name: gitlab.cosmian.com:5000/core/kms:${KMS_VERSION}_ci
       alias: kms_ci
     - redis:latest
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,10 +7,11 @@ variables:
   POSTGRES_DB: app_db
   POSTGRES_USER: app_user
   POSTGRES_PASSWORD: password
+  PGPORT: 5433
   # Postgrest
   PGRST_SERVER_HOST: localhost
   PGRST_SERVER_PORT: 3000
-  PGRST_DB_URI: postgres://app_user:password@localhost:5432/app_db
+  PGRST_DB_URI: postgres://app_user:password@localhost:5433/app_db
   PGRST_DB_SCHEMA: public
   PGRST_DB_ANON_ROLE: app_user
   PGRST_OPENAPI_SERVER_PROXY_URI: http://localhost:3000
@@ -19,7 +20,6 @@ variables:
   KMS_PUBLIC_PATH: /tmp
   KMS_PRIVATE_PATH: /tmp
   KMS_SHARED_PATH: /tmp
-
 
 stages:
   - prebuild
@@ -33,7 +33,7 @@ stages:
       alias: db
     - name: postgrest/postgrest
       alias: server
-    - name: gitlab.cosmian.com:5000/core/kms:2.2.0_ci
+    - name: gitlab.cosmian.com:5000/core/kms:2.3.0_ci
       alias: kms_ci
     - redis:latest
   before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 ---
+## [3.0.4] - 2022-10-14
+### Added
+- CI: use KMS version from Gitlab version
+- Use port 5433 for postgres container on Gitlab
+### Changed
+### Fixed
+### Removed
+
+---
 ## [3.0.3] - 2022-10-13
 ### Added
 - Add timings in console for the demo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3"
 services:
   kms:
     container_name: kms
-    image: gitlab.cosmian.com:5000/core/kms:2.3.0_ci
+    image: gitlab.cosmian.com:5000/core/kms:2.3.1_ci
     environment:
       - KMS_HOSTNAME=0.0.0.0
       - KMS_PUBLIC_PATH=/tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3"
 services:
   kms:
     container_name: kms
-    image: gitlab.cosmian.com:5000/core/kms:2.2.0_ci
+    image: gitlab.cosmian.com:5000/core/kms:2.3.0_ci
     environment:
       - KMS_HOSTNAME=0.0.0.0
       - KMS_PUBLIC_PATH=/tmp

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cloudproof_js",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "license": "MIT",
     "description": "Cosmian javascript client library",
     "main": "dist/cjs/index.js",

--- a/site/index.html
+++ b/site/index.html
@@ -28,7 +28,7 @@
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
     <base href="/" />
-    <title>Cloudproof JS Lib v3.0.3</title>
+    <title>Cloudproof JS Lib v3.0.4</title>
     <style>
       body {
         display: flex;


### PR DESCRIPTION
---
## [3.0.4] - 2022-10-14
### Added
- CI: use KMS version from Gitlab version
- Use port 5433 for postgres container on Gitlab
### Changed
### Fixed
### Removed