### PR TITLE
Simplify api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - encrypt/decrypt with the KMS
 - `Location.fromUuid()`
 - Verify non regression test vectors for CoverCrypt
+- New simple API for CoverCrypt (new functions `encrypt`, `decrypt`, `generateMasterKeys`, `generateUserSecretKey` and `rotateAttributes`)
 
 ### Changed
 
@@ -23,6 +24,10 @@ All notable changes to this project will be documented in this file.
 - Rename `ClearTextHeader` to `PlaintextHeader`
 - Rename `additionalData` to `headerMetadata`
 - Switch from Jest to Vitest
+
+### Removed
+
+- `options.generateGraphs` in the `upsert` function. Please use `generateAliases()` to build the keywords/nextwords (see VueJS or ReactJS examples)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Findex 0.11.0
+- Simplify `search` signature (move optional options to an `options` object at the end)
 - `decrypt` function for CoverCrypt now return an object containing the decrypted header metadata and the plaintext decrypted value
 - WASM files are now base64 inline in the lib
 - `KmipClient` is now `KmsClient`

--- a/download_wasm.sh
+++ b/download_wasm.sh
@@ -2,7 +2,7 @@
 
 set -exo pipefail
 
-FINDEX_VERSION=v0.11.1
+FINDEX_VERSION=v0.11.2
 COVER_CRYPT_VERSION=v8.0.1
 
 rm -rf src/pkg/findex
@@ -39,7 +39,7 @@ if [[ -z "${CI_JOB_TOKEN}" ]]; then
     popd || exit
 else
     curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "http://gitlab.cosmian.com/api/v4/projects/core%2Ffindex/jobs/artifacts/$FINDEX_VERSION/download?job=build_wasm"
-    unzip -o -j artifacts.zip "pkg/bundler/*" -d src/pkg/findex
+    unzip -o -j artifacts.zip "pkg/web/*" -d src/pkg/findex
 
     curl --location --output artifacts.zip --header "JOB-TOKEN: $CI_JOB_TOKEN" "http://gitlab.cosmian.com/api/v4/projects/core%2Fcover_crypt/jobs/artifacts/$COVER_CRYPT_VERSION/download?job=build_wasm"
     unzip -o -j artifacts.zip "pkg/web/*" -d src/pkg/cover_crypt

--- a/examples/reactjs/src/App.tsx
+++ b/examples/reactjs/src/App.tsx
@@ -11,6 +11,7 @@ import {
   CoverCrypt,
   KmsClient,
   UidsAndValuesToUpsert,
+  generateAliases,
 } from "cloudproof_js"
 import { FormEvent, useEffect, useState } from "react"
 
@@ -376,28 +377,33 @@ function App() {
     const { upsert } = await Findex()
 
     await upsert(
-      users.map((user) => {
-        return {
-          indexedValue: IndexedValue.fromLocation(
-            new Location(Uint8Array.from([user.id])),
-          ),
-          keywords: new Set([
-            Keyword.fromUtf8String(user.first),
-            Keyword.fromUtf8String(user.last),
-            Keyword.fromUtf8String(user.country),
-            Keyword.fromUtf8String(user.email),
-            Keyword.fromUtf8String(user.project.toString()),
-          ]),
-        }
+      users.flatMap((user) => {
+        return [
+          {
+            indexedValue: IndexedValue.fromLocation(
+              new Location(Uint8Array.from([user.id])),
+            ),
+            keywords: new Set([
+              Keyword.fromUtf8String(user.first),
+              Keyword.fromUtf8String(user.last),
+              Keyword.fromUtf8String(user.country),
+              Keyword.fromUtf8String(user.email),
+              Keyword.fromUtf8String(user.project.toString()),
+            ]),
+          },
+          ...(usingGraphs ? [
+              // Not required to generate aliases for all fields, you can choose which one you want to alias
+              ...generateAliases(user.first),
+              ...generateAliases(user.last),
+              ...generateAliases(user.email),
+          ] : []),
+        ]
       }),
       localMasterKey,
       FINDEX_LABEL,
       async (uids) => await fetchCallback("entries", uids),
       async (uidsAndValues) => await upsertCallback("entries", uidsAndValues),
       async (uidsAndValues) => await insertCallback("chains", uidsAndValues),
-      {
-        generateGraphs: usingGraphs,
-      },
     )
   }
 

--- a/examples/reactjs/src/App.tsx
+++ b/examples/reactjs/src/App.tsx
@@ -600,7 +600,6 @@ function App() {
         new Set(keywords),
         masterKey,
         FINDEX_LABEL,
-        1000,
         async (uids) => await fetchCallback("entries", uids),
         async (uids) => await fetchCallback("chains", uids),
       )
@@ -610,7 +609,6 @@ function App() {
           new Set([keyword]),
           masterKey,
           FINDEX_LABEL,
-          1000,
           async (uids) => await fetchCallback("entries", uids),
           async (uids) => await fetchCallback("chains", uids),
         )

--- a/examples/vuejs/src/App.vue
+++ b/examples/vuejs/src/App.vue
@@ -379,7 +379,6 @@ export default defineComponent({
           new Set(keywords),
           this.masterKey,
           FINDEX_LABEL,
-          1000,
           async (uids) => await this.fetchCallback("entries", uids),
           async (uids) => await this.fetchCallback("chains", uids),
         );
@@ -389,7 +388,6 @@ export default defineComponent({
             new Set([keyword]),
             this.masterKey,
             FINDEX_LABEL,
-            1000,
             async (uids) => await this.fetchCallback("entries", uids),
             async (uids) => await this.fetchCallback("chains", uids),
           );

--- a/examples/vuejs/tsconfig.config.json
+++ b/examples/vuejs/tsconfig.config.json
@@ -3,6 +3,7 @@
   "include": ["vite.config.*", "vitest.config.*", "cypress.config.*"],
   "compilerOptions": {
     "composite": true,
-    "types": ["node"]
-  }
+    "types": ["node"],
+    
+  },
 }

--- a/examples/vuejs/tsconfig.json
+++ b/examples/vuejs/tsconfig.json
@@ -5,9 +5,12 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "lib": [
+      "dom",
+      "es2019"
+    ],
   },
-
   "references": [
     {
       "path": "./tsconfig.config.json"

--- a/src/cover_crypt/cover_crypt.ts
+++ b/src/cover_crypt/cover_crypt.ts
@@ -1,7 +1,12 @@
 import init from "../pkg/cover_crypt/cosmian_cover_crypt"
-import { CoverCryptHybridDecryption } from "./decryption"
-import { CoverCryptHybridEncryption } from "./encryption"
-import { CoverCryptKeyGeneration } from "./key_generation"
+import { CoverCryptHybridDecryption, decrypt } from "./decryption"
+import { CoverCryptHybridEncryption, encrypt } from "./encryption"
+import {
+  CoverCryptKeyGeneration,
+  generateMasterKeys,
+  generateUserSecretKey,
+  rotateAttributes,
+} from "./key_generation"
 
 let initialized: Promise<void> | undefined
 
@@ -24,6 +29,13 @@ export async function CoverCrypt() {
   await initialized
 
   return {
+    encrypt,
+    decrypt,
+
+    generateMasterKeys,
+    generateUserSecretKey,
+    rotateAttributes,
+
     CoverCryptKeyGeneration,
     CoverCryptHybridDecryption,
     CoverCryptHybridEncryption,

--- a/src/cover_crypt/decryption.ts
+++ b/src/cover_crypt/decryption.ts
@@ -89,7 +89,7 @@ export class CoverCryptHybridDecryption {
    * @param  {Uint8Array} ciphertext the encrypted data
    * @param {object} options Additional optional options to the encryption
    * @param {Uint8Array} options.authenticationData Data use to authenticate the encrypted value when decrypting (if use, should be use during
-   * @returns the decrypted header metadata and the the plaintext value
+   * @returns the decrypted header metadata and the plaintext value
    */
   public decrypt(
     ciphertext: Uint8Array,

--- a/src/findex/findex.ts
+++ b/src/findex/findex.ts
@@ -345,9 +345,9 @@ export async function Findex() {
       fetchEntries: FetchEntries,
       fetchChains: FetchChains,
       options: {
-        maxResultsPerKeyword?: number,
-        maxGraphDepth?: number,
-        progress?: Progress,
+        maxResultsPerKeyword?: number
+        maxGraphDepth?: number
+        progress?: Progress
       } = {},
     ): Promise<IndexedValue[]> => {
       // convert key to a single representation
@@ -361,14 +361,20 @@ export async function Findex() {
       }
 
       const progress_: Progress =
-        typeof options.progress === "undefined" ? async () => true : options.progress
+        typeof options.progress === "undefined"
+          ? async () => true
+          : options.progress
 
       const serializedIndexedValues = await webassembly_search(
         masterKey.bytes,
         label.bytes,
         kws,
-        typeof options.maxResultsPerKeyword === "undefined" ? 1000 : options.maxResultsPerKeyword,
-        typeof options.maxGraphDepth === "undefined" ? 1000 : options.maxGraphDepth,
+        typeof options.maxResultsPerKeyword === "undefined"
+          ? 1000
+          : options.maxResultsPerKeyword,
+        typeof options.maxGraphDepth === "undefined"
+          ? 1000
+          : options.maxGraphDepth,
         async (serializedIndexedValues: Uint8Array[]) => {
           const indexedValues = serializedIndexedValues.map((bytes) => {
             return new IndexedValue(bytes)

--- a/src/findex/findex.ts
+++ b/src/findex/findex.ts
@@ -134,7 +134,7 @@ export interface IndexedEntry {
  * If keyword is "Thibaud" and minChars is 3 return these aliases ["Thi" => "Thibaud", "Thib" => "Thibaud", "Thiba" => "Thibaud", "Thibau" => "Thibaud"]
  *
  * @param keyword Generate aliases to this keyword
- * @param minChars Start at this number of caracters
+ * @param minChars Start at this number of characters
  * @returns IndexedEntry to add with upsert
  */
 export function generateAliases(
@@ -334,7 +334,7 @@ export async function Findex() {
      * @param {FetchChains} fetchChains callback to fetch the chains table
      * @param options Additional optional options to the search
      * @param options.maxResultsPerKeyword the maximum number of results per keyword
-     * @param options.maxGraphDepth automaticaly follow the nextwords to find only locations
+     * @param options.maxGraphDepth automatically follow the nextwords to find only locations
      * @param options.progress the optional callback of found values as the search graph is walked. Returning false stops the walk
      * @returns {Promise<IndexedValue[]>} a list of `IndexedValue`
      */

--- a/src/kms/kms.ts
+++ b/src/kms/kms.ts
@@ -55,7 +55,7 @@ export class KmsClient {
    * @param {string} apiKey optional, to authenticate to the KMS server
    */
   constructor(url: URL | string, apiKey: string | null = null) {
-    this.url = typeof url === "string" ? new URL(url): url
+    this.url = typeof url === "string" ? new URL(url) : url
     this.headers = {
       "Content-Type": "application/json; charset=utf-8",
     }

--- a/src/kms/kms.ts
+++ b/src/kms/kms.ts
@@ -54,8 +54,8 @@ export class KmsClient {
    * @param {URL} url of the KMS server
    * @param {string} apiKey optional, to authenticate to the KMS server
    */
-  constructor(url: URL, apiKey: string | null = null) {
-    this.url = url
+  constructor(url: URL | string, apiKey: string | null = null) {
+    this.url = typeof url === "string" ? new URL(url): url
     this.headers = {
       "Content-Type": "application/json; charset=utf-8",
     }

--- a/tests/cover_crypt.test.ts
+++ b/tests/cover_crypt.test.ts
@@ -25,6 +25,5 @@ test("Verify non-regression vector", async () => {
     const content = fs.readFileSync(testFolder + file, "utf8")
     const nrv = NonRegressionVector.fromJson(content)
     nrv.verify()
-    console.log("... OK: " + file)
   })
 })

--- a/tests/findex.bench.ts
+++ b/tests/findex.bench.ts
@@ -13,7 +13,6 @@ import { bench, describe } from "vitest"
 import { USERS } from "./data/users"
 import { randomBytes } from "crypto"
 
-
 describe("Wasm loading", async () => {
   bench("Load Findex functions", async () => {
     await Findex()

--- a/tests/findex.bench.ts
+++ b/tests/findex.bench.ts
@@ -13,6 +13,7 @@ import { bench, describe } from "vitest"
 import { USERS } from "./data/users"
 import { randomBytes } from "crypto"
 
+
 describe("Wasm loading", async () => {
   bench("Load Findex functions", async () => {
     await Findex()
@@ -162,7 +163,6 @@ describe("Findex Search", async () => {
       new Set([USERS[0].firstName]),
       masterKey,
       label,
-      1000,
       async (uids) => await fetchCallback(entryTable, uids),
       async (uids) => await fetchCallback(chainTable, uids),
     )

--- a/tests/findex.test.ts
+++ b/tests/findex.test.ts
@@ -117,7 +117,6 @@ test("upsert and search memory", async () => {
     new Set(["ROBERT"]),
     masterKey,
     label,
-    100,
     fetchEntries,
     fetchChains,
   )
@@ -127,7 +126,6 @@ test("upsert and search memory", async () => {
     new Set([new TextEncoder().encode("ROBERT")]),
     masterKey,
     label,
-    100,
     fetchEntries,
     fetchChains,
   )
@@ -137,7 +135,6 @@ test("upsert and search memory", async () => {
     new Set(["BOB"]),
     masterKey,
     label,
-    100,
     fetchEntries,
     fetchChains,
   )
@@ -439,7 +436,6 @@ async function run(
   upsertEntries: UpsertEntries,
   insertChains: InsertChains,
 ): Promise<void> {
-  console.log("Running!!!")
   const findex = await Findex()
   const masterKey = new FindexKey(randomBytes(32))
   const label = new Label(randomBytes(10))
@@ -469,7 +465,6 @@ async function run(
       new Set([USERS[0].firstName]),
       masterKey,
       label,
-      1000,
       fetchEntries,
       fetchChains,
     )
@@ -487,7 +482,6 @@ async function run(
       new Set(["Spain"]),
       masterKey,
       label,
-      1000,
       fetchEntries,
       fetchChains,
     )
@@ -519,7 +513,6 @@ async function run(
         new Set([keyword]),
         masterKey,
         label,
-        1000,
         fetchEntries,
         fetchChains,
       )
@@ -564,7 +557,6 @@ async function run(
       new Set(["Concurrent"]),
       masterKey,
       label,
-      1000,
       fetchEntries,
       fetchChains,
     )


### PR DESCRIPTION
- accept string instead of URL in `KmsClient`
- export functions for basic tasks instead of classes