### PR TITLE
Improve search API

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,15 @@ example_nodejs:
   script:
     - cd examples/nodejs
     - npm install
-    - node index.mjs 10
+    - node test.mjs 10
+
+example_imdb:
+  extends: .services
+  stage: test
+  script:
+    - cd examples/nodejs_search_imdb
+    - npm install
+    - node test.mjs
 
 pack:
   stage: pack

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,9 +92,9 @@ example_imdb:
   extends: .services
   stage: test
   script:
+    - cd examples/nodejs_search_imdb
     - curl https://datasets.imdbws.com/title.basics.tsv.gz --output imdb.tsv.gz
     - gzip -d imdb.tsv.gz
-    - cd examples/nodejs_search_imdb
     - npm install
     - node test.mjs
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,6 +92,8 @@ example_imdb:
   extends: .services
   stage: test
   script:
+    - curl https://datasets.imdbws.com/title.basics.tsv.gz --output imdb.tsv.gz
+    - gzip -d imdb.tsv.gz
     - cd examples/nodejs_search_imdb
     - npm install
     - node test.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 - Findex 0.12.0
 - Simplify `search` signature (move optional options to an `options` object at the end)
+- `search` now return only `Location` (no `NextWord`), use `rawSearch` to get the full `IndexedValue` list
 - `decrypt` function for CoverCrypt now return an object containing the decrypted header metadata and the plaintext decrypted value
 - WASM files are now base64 inline in the lib
 - `KmipClient` is now `KmsClient`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 - `options.generateGraphs` in the `upsert` function. Please use `generateAliases()` to build the keywords/nextwords (see VueJS or ReactJS examples)
+- In `Location`, `Keyword` and `Label`: `fromUtf8String()`, replaced by `fromString()`
 
 ### Fixed
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,4 +5,4 @@ This folder contains multiple examples to get started with CloudproofJS.
 - **If you want to use search (Findex) and encryption (CoverCrypt / KMS), and you know VueJS** go to [the VueJS example](./vuejs)
 - **If you want to use search (Findex) and encryption (CoverCrypt / KMS), and you know ReactJS** go to [the ReactJS example](./reactjs)
 - **If you want to use only encryption (CoverCrypt / KMS)** go to [the NodeJS example](./nodejs)
-- **If you want to use only search (Findex)** go to [the IMDB example](./nodejs_search_imdb)
+- **If you want to use only search (Findex)** go to [the IMDB example](./nodejs_search_imdb/index.mjs)

--- a/examples/nodejs/test.mjs
+++ b/examples/nodejs/test.mjs
@@ -119,12 +119,12 @@ import { fileURLToPath } from 'url';
 })()
 
 /**
-* Run a sub-script to do one task
-* 
-* @param filename name of the file to run
-* @param args additional arguments
-* @param shouldCrash return empty string if the program crash and shouldCrash is true
-*/
+ * Run a sub-script to do one task
+ * 
+ * @param filename name of the file to run
+ * @param args additional arguments
+ * @param shouldCrash return empty string if the program crash and shouldCrash is true
+ */
 async function run(filename, args = [], shouldCrash = false) {
   args = [path.join(dirname(fileURLToPath(import.meta.url)), filename), ...args];
   

--- a/examples/nodejs_search_imdb/index.mjs
+++ b/examples/nodejs_search_imdb/index.mjs
@@ -1,99 +1,50 @@
 import fs from "fs"
 import readline from "readline"
-import { IndexedValue, Location, Keyword, Findex, FindexKey, Label, generateAliases } from "cloudproof_js"
+import { IndexedValue, Location, Keyword, Findex, FindexKey, Label, callbacksExamplesBetterSqlite3 } from "cloudproof_js"
 import path from 'path';
 import {fileURLToPath} from 'url';
 import { randomBytes } from "crypto"
 import Database from 'better-sqlite3';
 
+let end = false;
+
+process.on('SIGINT', function() {
+  if (end) {
+    process.exit();
+  } else {
+    end = true;
+  }
+});
+
 // Check the IMDB file, create a stream to parse line by line.
 const NUMBER_OF_MOVIES_INSIDE_TSV = 9427158 - 1; // Number of line of the .tsv (useful to show percentage completion)
 const dataFilename = path.join(path.dirname(fileURLToPath(import.meta.url)), "imdb.tsv");
 if (!fs.existsSync(dataFilename)) {
-  console.warn(`Please download DB from "https://datasets.imdbws.com/title.akas.tsv.gz" and put it in "${dataFilename}"`)
+  console.warn(`Please download DB from "https://datasets.imdbws.com/title.basics.tsv.gz" and put it in "${dataFilename}"`)
   process.exit(1)
 }
 const input = fs.createReadStream(dataFilename)
 const rl = readline.createInterface({ input })
-
-// Start a new CSV file containing stats for further computing
-fs.writeFileSync('stats.csv', "numberOfMoviesIndexedSoFar,moviesSizeOnDisk,timeSqliteIndexSoFar,timeFindexSoFar,clearIndexSizeOnDisk,encryptedIndexSizeOnDisk\n");
-const csvStats = fs.createWriteStream("stats.csv", {flags:'a+'});
 
 // Init Findex with random key and random label
 const { upsert, search } = await Findex();
 const masterKey = new FindexKey(randomBytes(32))
 const label = new Label(randomBytes(10))
 
-// Init databases
-const dbClear = new Database(':memory:');
-if (fs.existsSync('database_clear.sqlite')) fs.unlinkSync('database_clear.sqlite')
-createMoviesTable(dbClear);
-
-const dbClearWithIndexes = new Database(':memory:');
-if (fs.existsSync('database_clear_with_indexes.sqlite')) fs.unlinkSync('database_clear_with_indexes.sqlite')
-createMoviesTable(dbClearWithIndexes);
-createMoviesIndexes(dbClearWithIndexes);
-
-const dbIndex = new Database(':memory:');
-if (fs.existsSync('findex_indexes.sqlite')) fs.unlinkSync('findex_indexes.sqlite')
-dbIndex.prepare("CREATE TABLE entry_table (uid BLOB PRIMARY KEY, value BLOB NOT NULL)").run();
-dbIndex.prepare("CREATE TABLE chain_table (uid BLOB PRIMARY KEY, value BLOB NOT NULL)").run();
-
-
-//
-// Prepare some useful SQL requests on different databases
-// `prepare` a statement is a costly operation we don't want to do on every line (or in every callback)
-//
-
-const insertMovie = dbClear.prepare(`INSERT INTO movies (id, type, title, start_year, genre1, genre2, genre3) VALUES(?, ?, ?, ?, ?, ?, ?)`);
-const insertMovieWithIndexes = dbClearWithIndexes.prepare(`INSERT INTO movies (id, type, title, start_year, genre1, genre2, genre3) VALUES(?, ?, ?, ?, ?, ?, ?)`);
-
-const sizeEntryTableStmt = dbIndex.prepare(`SELECT SUM(LENGTH(uid) + LENGTH(value)) as sum FROM entry_table`);
-const sizeChainTableStmt = dbIndex.prepare(`SELECT SUM(LENGTH(uid) + LENGTH(value)) as sum FROM chain_table`);
-const countEntryTableStmt = dbIndex.prepare(`SELECT COUNT(*) as count FROM entry_table`);
-const countChainTableStmt = dbIndex.prepare(`SELECT COUNT(*) as count FROM chain_table`);
-
-const upsertIntoChainTableStmt = dbIndex.prepare(`INSERT OR REPLACE INTO chain_table (uid, value) VALUES(?, ?)`)
-const upsertIntoEntryTableStmt = dbIndex.prepare(`INSERT INTO entry_table (uid, value) VALUES (?, ?)  ON CONFLICT (uid)  DO UPDATE SET value = ? WHERE value = ?`)
-const selectOneEntryTableItemStmt = dbIndex.prepare(`SELECT value FROM entry_table WHERE uid = ?`)
-
-// Save some prepare statements inside these objects
-// These queries have `WHERE IN (?, ?, ?)` so we need multiple prepare
-// statements for each different number of parameters (but we can reuse them if 
-// two callbacks have the same number of parameters)
-const fetchMultipleEntryTableStmt = {};
-const fetchMultipleChainTableStmt = {};
-
-// Some statistics on callbacks executions
-let fetchEntryTableCallbackCount = 0;
-let fetchChainTableCallbackCount = 0;
-let insertChainTableCallbackCount = 0;
-let upsertEntryTableCallbackCount = 0;
-
-// Number of movies to index (stop after this count)
-const NUMBER_OF_MOVIES = 100 * 1000;
-
-const USE_GRAPHS = true;
+const db = new Database(":memory:");
+const callbacks = callbacksExamplesBetterSqlite3(db);
 
 // Number of movies to index in a single `upsert` call
-const MAX_UPSERT_LINES = 10 * 1000;
+let numberOfMoviesIndexedSoFar = 0;
+const MAX_UPSERT_LINES = 1000;
 
-let numberOfMoviesIndexedSoFar = 1
-let numberOfMoviesIndexedSinceLastStatsPrint = 1
-
-let percentageDuringLastStatsPrint = 0;
 let latestPercentageShown;
-
-let timeFindexSoFar = 0;
-let timeFindexSinceLastStatsPrint = 0;
-let timeSqliteIndexSoFar = 0;
-let timeSqliteIndexSinceLastStatsPrint = 0;
 
 let toUpsert = [];
 
 let header = true;
-let end = false;
+
+console.log("Press Ctrl-C to quit the importation and start the search.");
 
 for await (const line of rl) {
   // Skip pass the header
@@ -101,8 +52,6 @@ for await (const line of rl) {
     header = false
     continue
   }
-  numberOfMoviesIndexedSoFar++;
-  numberOfMoviesIndexedSinceLastStatsPrint++;
 
   const info = line.split('\t')
 
@@ -118,186 +67,70 @@ for await (const line of rl) {
     toInsert.push(null);
   }
 
-  {
-    const insertWithoutIndexStart = performance.now();
-    insertMovie.run(...toInsert)
-    const insertWithoutIndexTime = performance.now() - insertWithoutIndexStart;
-
-    const insertWithIndexStart = performance.now();
-    insertMovieWithIndexes.run(...toInsert)
-    timeSqliteIndexSinceLastStatsPrint += performance.now() - insertWithIndexStart - insertWithoutIndexTime
-  }
-
   toUpsert.push({
-    indexedValue: IndexedValue.fromLocation(Location.fromUtf8String(info[0])),
-    keywords: new Set(keywords.map((keyword) => Keyword.fromUtf8String(keyword))),
+    indexedValue: Location.fromUtf8String(info[0]),
+    keywords,
   })
 
-  if (USE_GRAPHS) {
-    toUpsert = [...toUpsert, ...generateAliases(info[2])];
-  }
+  numberOfMoviesIndexedSoFar++;
 
   const percentage = numberOfMoviesIndexedSoFar / NUMBER_OF_MOVIES_INSIDE_TSV;
   const percentageToShow = formatPercentage(percentage);
-  if (toUpsert.length >= MAX_UPSERT_LINES || percentageToShow !== latestPercentageShown) {
-    const insertFindexStart = performance.now();
+  if (percentageToShow !== latestPercentageShown) {
+    process.stdout.clearLine(0);
+    process.stdout.cursorTo(0);
+    process.stdout.write(`Progress: ${percentageToShow}`);
+    latestPercentageShown = percentageToShow
+  }
+
+  if (toUpsert.length >= MAX_UPSERT_LINES || end) {
     await upsert(
       toUpsert,
       masterKey,
       label,
-      async (uids) => await fetchCallback("entry_table", uids),
-      async (uidsAndValues) => await upsertCallback(uidsAndValues),
-      async (uidsAndValues) => await insertCallback(uidsAndValues),
+      callbacks.fetchEntries,
+      callbacks.upsertEntries,
+      callbacks.insertChains,
     )
-    timeFindexSinceLastStatsPrint += performance.now() - insertFindexStart
 
     toUpsert = []
 
-
-    if (percentageToShow !== latestPercentageShown) {
-      process.stdout.clearLine(0);
-      process.stdout.cursorTo(0);
-      process.stdout.write(`Progress: ${percentageToShow}`);
-      latestPercentageShown = percentageToShow
-    }
-
-    if (numberOfMoviesIndexedSoFar >= NUMBER_OF_MOVIES) {
-      end = true;
-    }
-
-    if (Math.floor(percentage * 100) > percentageDuringLastStatsPrint || end) {
-      timeFindexSoFar += timeFindexSinceLastStatsPrint
-      timeSqliteIndexSoFar += timeSqliteIndexSinceLastStatsPrint
-
-      percentageDuringLastStatsPrint = Math.floor(percentage * 100)
-
-      console.log()
-      console.log('------------------')
-      console.log()
-
-      const { sum: entryTableSize } = sizeEntryTableStmt.get()
-      const { sum: chainTableSize } = sizeChainTableStmt.get()
-      const { count: entryTableCount } = countEntryTableStmt.get()
-      const { count: chainTableCount } = countChainTableStmt.get()
-
-      console.log()
-      
-      console.log(`Callbacks Before Search:`);
-      console.log(`\tfetchEntryTableCallbackCount ${fetchEntryTableCallbackCount}`);
-      console.log(`\tfetchChainTableCallbackCount ${fetchChainTableCallbackCount}`);
-      console.log(`\tinsertChainTableCallbackCount ${insertChainTableCallbackCount}`);
-      console.log(`\tupsertEntryTableCallbackCount ${upsertEntryTableCallbackCount}`);
-
-      console.log()
-
-      let findexResults;
-      {
-        const searchNow = performance.now()
-
-        const results = await search(
-          new Set(["Documentary"]),
-          masterKey,
-          label,
-          async (uids) => await fetchCallback("entry_table", uids),
-          async (uids) => await fetchCallback("chain_table", uids),
-          {
-            maxResultsPerKeyword: 1000,
-          },
-        )
-
-        findexResults = new Set(results.map((indexedLocation) => new TextDecoder().decode(indexedLocation.bytes.slice(1))))
-
-        console.log(`${formatNumber(findexResults.size)} documentaries found with Findex in ${formatNumber((performance.now() - searchNow))}ms.`);
-      }
-      {
-        const searchNow = performance.now()
-
-        const results = new Set(dbClear.prepare(`SELECT id FROM movies WHERE genre1 = 'Documentary' OR genre2 = 'Documentary' OR genre3 = 'Documentary' LIMIT 1000`).all().map(({ id }) => id));
-
-        console.log(`${formatNumber(results.size)} documentaries found with no index in ${formatNumber((performance.now() - searchNow))}ms.`);
-      }
-
-      await dbClear.backup('database_clear.sqlite')
-      const moviesSizeOnDisk = fs.statSync("database_clear.sqlite").size
-
-
-
-      {
-        const searchNow = performance.now()
-
-        const results = new Set(dbClearWithIndexes.prepare(`SELECT id FROM movies WHERE genre1 = 'Documentary' OR genre2 = 'Documentary' OR genre3 = 'Documentary' LIMIT 1000`).all().map(({ id }) => id));
-
-        console.log(`${formatNumber(results.size)} documentaries found with cleartext index in ${formatNumber((performance.now() - searchNow))}ms.`);
-      }
-
-      await dbClearWithIndexes.backup('database_clear_with_indexes.sqlite')
-      const clearIndexSizeOnDisk = fs.statSync("database_clear_with_indexes.sqlite").size
-
-      await dbIndex.backup('findex_indexes.sqlite')
-      const encryptedIndexSizeOnDisk = fs.statSync("findex_indexes.sqlite").size
-
-      console.log()
-      
-      console.log(`Callbacks After Search:`);
-      console.log(`\tfetchEntryTableCallbackCount ${fetchEntryTableCallbackCount}`);
-      console.log(`\tfetchChainTableCallbackCount ${fetchChainTableCallbackCount}`);
-      console.log(`\tinsertChainTableCallbackCount ${insertChainTableCallbackCount}`);
-      console.log(`\tupsertEntryTableCallbackCount ${upsertEntryTableCallbackCount}`);
-
-    
-      console.log()
-
-      console.log(`${formatNumber(numberOfMoviesIndexedSinceLastStatsPrint)} movies indexed:\n\tSQLite index in ${formatNumber(timeSqliteIndexSinceLastStatsPrint / 1000)}s\n\tFindex index in ${formatNumber(timeFindexSinceLastStatsPrint / 1000)}s`)
-      console.log(`${formatNumber(numberOfMoviesIndexedSoFar)} movies indexed in total (${formatNumber(moviesSizeOnDisk / 1024 / 1024)}MB on disk)\n\tSQLite index in ${formatNumber(timeSqliteIndexSoFar / 1000)}s \n\tFindex index in ${formatNumber(timeFindexSoFar / 1000)}s`)
-      console.log()
-
-      console.log(`Table entry_table (${formatNumber(entryTableCount)} lines) is ${formatNumber(entryTableSize / 1024 / 1024)}MB`)
-      console.log(`Table chain_table (${formatNumber(chainTableCount)} lines) is ${formatNumber(chainTableSize / 1024 / 1024)}MB`)
-
-      console.log()
-      
-      console.log(`Cleartext indexes on disk are ${formatNumber(clearIndexSizeOnDisk / 1024 / 1024)}MB`)
-      console.log(`Encrypted indexes on disk are ${formatNumber(encryptedIndexSizeOnDisk / 1024 / 1024)}MB (x${formatNumber((encryptedIndexSizeOnDisk - clearIndexSizeOnDisk) / clearIndexSizeOnDisk)})`)
-      
-      console.log()
-      console.log()
-
-      csvStats.write(`${numberOfMoviesIndexedSoFar},${moviesSizeOnDisk},${timeSqliteIndexSoFar},${timeFindexSoFar},${clearIndexSizeOnDisk},${encryptedIndexSizeOnDisk}\n`)
-
-      numberOfMoviesIndexedSinceLastStatsPrint = 1
-
-      if (end) {
-        break;
-      }
-    }
+    if (end) break;
   }
 }
 
-/**
- * @param db db 
- */
-function createMoviesTable(db) {
-  db.prepare(`CREATE TABLE movies (
-    id TEXT PRIMARY KEY,
-    type TEXT NOT NULL,
-    title TEXT NOT NULL,
-    start_year INTEGER NOT NULL,
-    genre1 TEXT,
-    genre2 TEXT,
-    genre3 TEXT
-  )`).run();
-}
+const queries = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  terminal: false
+});
 
-/**
- * @param db db 
- */
-function createMoviesIndexes(db) {
-  db.prepare('CREATE INDEX idx_type ON movies(type)').run();
-  db.prepare('CREATE INDEX idx_title ON movies(title)').run();
-  db.prepare('CREATE INDEX idx_start_year ON movies(start_year)').run();
-  db.prepare('CREATE INDEX idx_genre1 ON movies(genre1)').run();
-  db.prepare('CREATE INDEX idx_genre2 ON movies(genre2)').run();
-  db.prepare('CREATE INDEX idx_genre3 ON movies(genre3)').run();
+console.log();
+console.log();
+console.log();
+console.log("Press CTRL-C again to quit the search.")
+process.stdout.write("Search for: ");
+
+for await (const query of queries) {
+  console.log(query);
+
+  const results = await search(
+    [query],
+    masterKey,
+    label,
+    callbacks.fetchEntries,
+    callbacks.fetchChains,
+    {
+      maxResultsPerKeyword: 1000,
+    },
+  );
+
+  console.log(`Searching for ${query} returned ${results.length} results:`)
+  for (const result of results) {
+    console.log(`\t- https://www.imdb.com/title/${result}`);
+  }
+  console.log()
+  process.stdout.write("Search for: ");
 }
 
 /**
@@ -309,62 +142,4 @@ function formatPercentage(value) {
     style: 'percent',
     maximumFractionDigits: 2,
   }).format(value)
-}
-
-/**
- * @param value raw
- * @returns formatted
- */
-function formatNumber(value) {
-  return new Intl.NumberFormat('en-US', {
-    maximumFractionDigits: 2,
-  }).format(value);
-}
-
-async function fetchCallback(
-  table,
-  uids,
-) {
-  let fetchMultipleStmt;
-  if (table === 'entry_table') {
-    fetchEntryTableCallbackCount++
-    fetchMultipleStmt = fetchMultipleEntryTableStmt[uids.length] || (fetchMultipleEntryTableStmt[uids.length] = dbIndex.prepare(`
-      SELECT uid, value
-      FROM entry_table
-      WHERE uid IN (${uids.map(() => "?").join(",")})
-    `))
-  } else {
-    fetchChainTableCallbackCount++
-    fetchMultipleStmt = fetchMultipleChainTableStmt[uids.length] || (fetchMultipleChainTableStmt[uids.length] = dbIndex.prepare(`
-      SELECT uid, value
-      FROM chain_table
-      WHERE uid IN (${uids.map(() => "?").join(",")})
-    `))
-  }
-  
-  return fetchMultipleStmt.all(...uids);
-}
-async function insertCallback(
-  uidsAndValues,
-) {
-  insertChainTableCallbackCount++
-  for (const { uid, value } of uidsAndValues) {
-    upsertIntoChainTableStmt.run(uid, value);
-  }
-}
-async function upsertCallback(
-  uidsAndValues,
-) {
-  upsertEntryTableCallbackCount++
-
-  const rejected = []
-  for (const { uid, oldValue, newValue } of uidsAndValues) {
-    const changed = upsertIntoEntryTableStmt.run(uid, newValue, newValue, oldValue);
-    if (!changed) {
-      const valueInSqlite = selectOneEntryTableItemStmt.get(uid)
-      rejected.push({ uid, value: valueInSqlite })
-    }
-  }
-
-  return rejected
 }

--- a/examples/nodejs_search_imdb/index.mjs
+++ b/examples/nodejs_search_imdb/index.mjs
@@ -1,6 +1,6 @@
 import fs from "fs"
 import readline from "readline"
-import { IndexedValue, Location, Keyword, Findex, FindexKey, Label, callbacksExamplesBetterSqlite3 } from "cloudproof_js"
+import { Location, Findex, FindexKey, Label, callbacksExamplesBetterSqlite3 } from "cloudproof_js"
 import path from 'path';
 import {fileURLToPath} from 'url';
 import { randomBytes } from "crypto"
@@ -77,8 +77,8 @@ for await (const line of rl) {
   const percentage = numberOfMoviesIndexedSoFar / NUMBER_OF_MOVIES_INSIDE_TSV;
   const percentageToShow = formatPercentage(percentage);
   if (percentageToShow !== latestPercentageShown) {
-    process.stdout.clearLine(0);
-    process.stdout.cursorTo(0);
+    readline.clearLine(process.stdout, 0);
+    readline.cursorTo(process.stdout, 0, null);
     process.stdout.write(`Progress: ${percentageToShow}`);
     latestPercentageShown = percentageToShow
   }

--- a/examples/nodejs_search_imdb/index.mjs
+++ b/examples/nodejs_search_imdb/index.mjs
@@ -68,7 +68,7 @@ for await (const line of rl) {
   }
 
   toUpsert.push({
-    indexedValue: Location.fromUtf8String(info[0]),
+    indexedValue: Location.fromString(info[0]),
     keywords,
   })
 

--- a/examples/nodejs_search_imdb/index_with_stats.mjs
+++ b/examples/nodejs_search_imdb/index_with_stats.mjs
@@ -117,8 +117,8 @@ for await (const line of rl) {
   }
 
   toUpsert.push({
-    indexedValue: IndexedValue.fromLocation(Location.fromUtf8String(info[0])),
-    keywords: new Set(keywords.map((keyword) => Keyword.fromUtf8String(keyword))),
+    indexedValue: IndexedValue.fromLocation(Location.fromString(info[0])),
+    keywords: new Set(keywords.map((keyword) => Keyword.fromString(keyword))),
   })
 
   if (USE_GRAPHS) {

--- a/examples/nodejs_search_imdb/index_with_stats.mjs
+++ b/examples/nodejs_search_imdb/index_with_stats.mjs
@@ -1,0 +1,325 @@
+import fs from "fs"
+import readline from "readline"
+import { IndexedValue, Location, Keyword, Findex, FindexKey, Label, generateAliases, callbacksExamplesBetterSqlite3 } from "cloudproof_js"
+import path from 'path';
+import {fileURLToPath} from 'url';
+import { randomBytes } from "crypto"
+import Database from 'better-sqlite3';
+
+// Check the IMDB file, create a stream to parse line by line.
+const NUMBER_OF_MOVIES_INSIDE_TSV = 9427158 - 1; // Number of line of the .tsv (useful to show percentage completion)
+const dataFilename = path.join(path.dirname(fileURLToPath(import.meta.url)), "imdb.tsv");
+if (!fs.existsSync(dataFilename)) {
+  console.warn(`Please download DB from "https://datasets.imdbws.com/title.basics.tsv.gz" and put it in "${dataFilename}"`)
+  process.exit(1)
+}
+const input = fs.createReadStream(dataFilename)
+const rl = readline.createInterface({ input })
+
+// Start a new CSV file containing stats for further computing
+fs.writeFileSync('stats.csv', "numberOfMoviesIndexedSoFar,moviesSizeOnDisk,timeSqliteIndexSoFar,timeFindexSoFar,clearIndexSizeOnDisk,encryptedIndexSizeOnDisk\n");
+const csvStats = fs.createWriteStream("stats.csv", {flags:'a+'});
+
+// Init Findex with random key and random label
+const { upsert, search } = await Findex();
+const masterKey = new FindexKey(randomBytes(32))
+const label = new Label(randomBytes(10))
+
+// Init databases
+const dbClear = new Database(':memory:');
+if (fs.existsSync('database_clear.sqlite')) fs.unlinkSync('database_clear.sqlite')
+createMoviesTable(dbClear);
+
+const dbClearWithIndexes = new Database(':memory:');
+if (fs.existsSync('database_clear_with_indexes.sqlite')) fs.unlinkSync('database_clear_with_indexes.sqlite')
+createMoviesTable(dbClearWithIndexes);
+createMoviesIndexes(dbClearWithIndexes);
+
+const dbIndex = new Database(':memory:');
+if (fs.existsSync('findex_indexes.sqlite')) fs.unlinkSync('findex_indexes.sqlite')
+const callbacks = callbacksExamplesBetterSqlite3(dbIndex);
+
+
+//
+// Prepare some useful SQL requests on different databases
+// `prepare` a statement is a costly operation we don't want to do on every line (or in every callback)
+//
+
+const insertMovie = dbClear.prepare(`INSERT INTO movies (id, type, title, start_year, genre1, genre2, genre3) VALUES(?, ?, ?, ?, ?, ?, ?)`);
+const insertMovieWithIndexes = dbClearWithIndexes.prepare(`INSERT INTO movies (id, type, title, start_year, genre1, genre2, genre3) VALUES(?, ?, ?, ?, ?, ?, ?)`);
+
+const sizeEntryTableStmt = dbIndex.prepare(`SELECT SUM(LENGTH(uid) + LENGTH(value)) as sum FROM entries`);
+const sizeChainTableStmt = dbIndex.prepare(`SELECT SUM(LENGTH(uid) + LENGTH(value)) as sum FROM chains`);
+const countEntryTableStmt = dbIndex.prepare(`SELECT COUNT(*) as count FROM entries`);
+const countChainTableStmt = dbIndex.prepare(`SELECT COUNT(*) as count FROM chains`);
+
+// Some statistics on callbacks executions
+let fetchEntryTableCallbackCount = 0;
+let fetchChainTableCallbackCount = 0;
+let insertChainTableCallbackCount = 0;
+let upsertEntryTableCallbackCount = 0;
+
+// Number of movies to index (stop after this count)
+const NUMBER_OF_MOVIES = 100 * 1000;
+
+const USE_GRAPHS = true;
+
+// Number of movies to index in a single `upsert` call
+const MAX_UPSERT_LINES = 10 * 1000;
+
+let numberOfMoviesIndexedSoFar = 1
+let numberOfMoviesIndexedSinceLastStatsPrint = 1
+
+let percentageDuringLastStatsPrint = 0;
+let latestPercentageShown;
+
+let timeFindexSoFar = 0;
+let timeFindexSinceLastStatsPrint = 0;
+let timeSqliteIndexSoFar = 0;
+let timeSqliteIndexSinceLastStatsPrint = 0;
+
+let toUpsert = [];
+
+let header = true;
+let end = false;
+
+for await (const line of rl) {
+  // Skip pass the header
+  if (header) {
+    header = false
+    continue
+  }
+  numberOfMoviesIndexedSoFar++;
+  numberOfMoviesIndexedSinceLastStatsPrint++;
+
+  const info = line.split('\t')
+
+  const keywords = [
+    info[1],
+    info[2],
+    info[5],
+    ...info[8].split(','),
+  ]
+
+  const toInsert = [info[0], ...keywords];
+  while (toInsert.length < 7) {
+    toInsert.push(null);
+  }
+
+  {
+    const insertWithoutIndexStart = performance.now();
+    insertMovie.run(...toInsert)
+    const insertWithoutIndexTime = performance.now() - insertWithoutIndexStart;
+
+    const insertWithIndexStart = performance.now();
+    insertMovieWithIndexes.run(...toInsert)
+    timeSqliteIndexSinceLastStatsPrint += performance.now() - insertWithIndexStart - insertWithoutIndexTime
+  }
+
+  toUpsert.push({
+    indexedValue: IndexedValue.fromLocation(Location.fromUtf8String(info[0])),
+    keywords: new Set(keywords.map((keyword) => Keyword.fromUtf8String(keyword))),
+  })
+
+  if (USE_GRAPHS) {
+    toUpsert = [...toUpsert, ...generateAliases(info[2])];
+  }
+
+  const percentage = numberOfMoviesIndexedSoFar / NUMBER_OF_MOVIES_INSIDE_TSV;
+  const percentageToShow = formatPercentage(percentage);
+  if (toUpsert.length >= MAX_UPSERT_LINES || percentageToShow !== latestPercentageShown) {
+    const insertFindexStart = performance.now();
+    await upsert(
+      toUpsert,
+      masterKey,
+      label,
+      async (uids) => {
+        fetchEntryTableCallbackCount++
+        return await callbacks.fetchEntries(uids)
+      },
+      async (uidsAndValues) => {
+        upsertEntryTableCallbackCount++
+        return await callbacks.upsertEntries(uidsAndValues)
+      },
+      async (uidsAndValues) => {
+        insertChainTableCallbackCount++
+        return await callbacks.insertChains(uidsAndValues)
+      },
+    )
+    timeFindexSinceLastStatsPrint += performance.now() - insertFindexStart
+
+    toUpsert = []
+
+
+    if (percentageToShow !== latestPercentageShown) {
+      process.stdout.clearLine(0);
+      process.stdout.cursorTo(0);
+      process.stdout.write(`Progress: ${percentageToShow}`);
+      latestPercentageShown = percentageToShow
+    }
+
+    if (numberOfMoviesIndexedSoFar >= NUMBER_OF_MOVIES) {
+      end = true;
+    }
+
+    if (Math.floor(percentage * 100) > percentageDuringLastStatsPrint || end) {
+      timeFindexSoFar += timeFindexSinceLastStatsPrint
+      timeSqliteIndexSoFar += timeSqliteIndexSinceLastStatsPrint
+
+      percentageDuringLastStatsPrint = Math.floor(percentage * 100)
+
+      console.log()
+      console.log('------------------')
+      console.log()
+
+      const { sum: entryTableSize } = sizeEntryTableStmt.get()
+      const { sum: chainTableSize } = sizeChainTableStmt.get()
+      const { count: entryTableCount } = countEntryTableStmt.get()
+      const { count: chainTableCount } = countChainTableStmt.get()
+
+      console.log()
+      
+      console.log(`Callbacks Before Search:`);
+      console.log(`\tfetchEntryTableCallbackCount ${fetchEntryTableCallbackCount}`);
+      console.log(`\tfetchChainTableCallbackCount ${fetchChainTableCallbackCount}`);
+      console.log(`\tinsertChainTableCallbackCount ${insertChainTableCallbackCount}`);
+      console.log(`\tupsertEntryTableCallbackCount ${upsertEntryTableCallbackCount}`);
+
+      console.log()
+
+      let findexResults;
+      {
+        const searchNow = performance.now()
+
+        const results = await search(
+          new Set(["Documentary"]),
+          masterKey,
+          label,
+          async (uids) => {
+            fetchEntryTableCallbackCount++
+            return await callbacks.fetchEntries(uids)
+          },
+          async (uids) => {
+            fetchChainTableCallbackCount++
+            return await callbacks.fetchChains(uids)
+          },
+          {
+            maxResultsPerKeyword: 1000,
+          },
+        )
+
+        findexResults = new Set(results.map((indexedLocation) => new TextDecoder().decode(indexedLocation.bytes.slice(1))))
+
+        console.log(`${formatNumber(findexResults.size)} documentaries found with Findex in ${formatNumber((performance.now() - searchNow))}ms.`);
+      }
+      {
+        const searchNow = performance.now()
+
+        const results = new Set(dbClear.prepare(`SELECT id FROM movies WHERE genre1 = 'Documentary' OR genre2 = 'Documentary' OR genre3 = 'Documentary' LIMIT 1000`).all().map(({ id }) => id));
+
+        console.log(`${formatNumber(results.size)} documentaries found with no index in ${formatNumber((performance.now() - searchNow))}ms.`);
+      }
+
+      await dbClear.backup('database_clear.sqlite')
+      const moviesSizeOnDisk = fs.statSync("database_clear.sqlite").size
+
+
+
+      {
+        const searchNow = performance.now()
+
+        const results = new Set(dbClearWithIndexes.prepare(`SELECT id FROM movies WHERE genre1 = 'Documentary' OR genre2 = 'Documentary' OR genre3 = 'Documentary' LIMIT 1000`).all().map(({ id }) => id));
+
+        console.log(`${formatNumber(results.size)} documentaries found with cleartext index in ${formatNumber((performance.now() - searchNow))}ms.`);
+      }
+
+      await dbClearWithIndexes.backup('database_clear_with_indexes.sqlite')
+      const clearIndexSizeOnDisk = fs.statSync("database_clear_with_indexes.sqlite").size
+
+      await dbIndex.backup('findex_indexes.sqlite')
+      const encryptedIndexSizeOnDisk = fs.statSync("findex_indexes.sqlite").size
+
+      console.log()
+      
+      console.log(`Callbacks After Search:`);
+      console.log(`\tfetchEntryTableCallbackCount ${fetchEntryTableCallbackCount}`);
+      console.log(`\tfetchChainTableCallbackCount ${fetchChainTableCallbackCount}`);
+      console.log(`\tinsertChainTableCallbackCount ${insertChainTableCallbackCount}`);
+      console.log(`\tupsertEntryTableCallbackCount ${upsertEntryTableCallbackCount}`);
+
+    
+      console.log()
+
+      console.log(`${formatNumber(numberOfMoviesIndexedSinceLastStatsPrint)} movies indexed:\n\tSQLite index in ${formatNumber(timeSqliteIndexSinceLastStatsPrint / 1000)}s\n\tFindex index in ${formatNumber(timeFindexSinceLastStatsPrint / 1000)}s`)
+      console.log(`${formatNumber(numberOfMoviesIndexedSoFar)} movies indexed in total (${formatNumber(moviesSizeOnDisk / 1024 / 1024)}MB on disk)\n\tSQLite index in ${formatNumber(timeSqliteIndexSoFar / 1000)}s \n\tFindex index in ${formatNumber(timeFindexSoFar / 1000)}s`)
+      console.log()
+
+      console.log(`Table entries (${formatNumber(entryTableCount)} lines) is ${formatNumber(entryTableSize / 1024 / 1024)}MB`)
+      console.log(`Table chains (${formatNumber(chainTableCount)} lines) is ${formatNumber(chainTableSize / 1024 / 1024)}MB`)
+
+      console.log()
+      
+      console.log(`Cleartext indexes on disk are ${formatNumber(clearIndexSizeOnDisk / 1024 / 1024)}MB`)
+      console.log(`Encrypted indexes on disk are ${formatNumber(encryptedIndexSizeOnDisk / 1024 / 1024)}MB (x${formatNumber((encryptedIndexSizeOnDisk - clearIndexSizeOnDisk) / clearIndexSizeOnDisk)})`)
+      
+      console.log()
+      console.log()
+
+      csvStats.write(`${numberOfMoviesIndexedSoFar},${moviesSizeOnDisk},${timeSqliteIndexSoFar},${timeFindexSoFar},${clearIndexSizeOnDisk},${encryptedIndexSizeOnDisk}\n`)
+
+      numberOfMoviesIndexedSinceLastStatsPrint = 1
+
+      if (end) {
+        break;
+      }
+    }
+  }
+}
+
+/**
+ * @param db db 
+ */
+function createMoviesTable(db) {
+  db.prepare(`CREATE TABLE movies (
+    id TEXT PRIMARY KEY,
+    type TEXT NOT NULL,
+    title TEXT NOT NULL,
+    start_year INTEGER NOT NULL,
+    genre1 TEXT,
+    genre2 TEXT,
+    genre3 TEXT
+  )`).run();
+}
+
+/**
+ * @param db db 
+ */
+function createMoviesIndexes(db) {
+  db.prepare('CREATE INDEX idx_type ON movies(type)').run();
+  db.prepare('CREATE INDEX idx_title ON movies(title)').run();
+  db.prepare('CREATE INDEX idx_start_year ON movies(start_year)').run();
+  db.prepare('CREATE INDEX idx_genre1 ON movies(genre1)').run();
+  db.prepare('CREATE INDEX idx_genre2 ON movies(genre2)').run();
+  db.prepare('CREATE INDEX idx_genre3 ON movies(genre3)').run();
+}
+
+/**
+ * @param value raw
+ * @returns formatted
+ */
+function formatPercentage(value) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'percent',
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+/**
+ * @param value raw
+ * @returns formatted
+ */
+function formatNumber(value) {
+  return new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 2,
+  }).format(value);
+}

--- a/examples/nodejs_search_imdb/test.mjs
+++ b/examples/nodejs_search_imdb/test.mjs
@@ -1,0 +1,38 @@
+import { spawn } from 'node:child_process'
+import path, { dirname } from 'path'
+import { fileURLToPath } from 'url';
+
+const process = spawn('node', [
+    path.join(dirname(fileURLToPath(import.meta.url)), 'index.mjs'),
+]);
+process.stdin.setEncoding('utf-8');
+
+let stdout = ''
+
+process.stdout.on('data', (data) => {
+    const dataAsString = new TextDecoder().decode(data)
+    console.log(dataAsString)
+    stdout = stdout + dataAsString
+});
+process.stderr.on('data', (data) => {
+    throw new Error(`Error while running: ${data}`);
+});
+
+// Wait 10 seconds before killing the importation
+await new Promise((resolve) => setTimeout(resolve, 10 * 100));
+
+process.kill('SIGINT')
+
+await new Promise((resolve) => setTimeout(resolve, 1 * 100));
+process.stdin.write("Documentary\n");
+process.stdin.end();
+
+// Wait the search results
+await new Promise((resolve) => setTimeout(resolve, 10 * 100));
+
+if (! stdout.includes('https://www.imdb.com/title/tt0009910')) {
+    console.log(stdout)
+    throw new Error("Stdout doesn't contains the documentary link")
+}
+
+

--- a/examples/reactjs/src/App.tsx
+++ b/examples/reactjs/src/App.tsx
@@ -378,7 +378,7 @@ function App() {
       users.flatMap((user) => {
         return [
           {
-            indexedValue: Location.fromUtf8String(user.id.toString()),
+            indexedValue: Location.fromString(user.id.toString()),
             keywords: [
               user.first,
               user.last,

--- a/examples/vuejs/src/App.vue
+++ b/examples/vuejs/src/App.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Policy, PolicyAxis, CoverCrypt, CoverCryptMasterKey, Findex, FindexKey, type UidsAndValues, Label, IndexedValue, Location, Keyword, KmsClient, type CoverCryptHybridEncryption, type UidsAndValuesToUpsert, generateAliases } from 'cloudproof_js';
+import { Policy, PolicyAxis, CoverCrypt, Findex, FindexKey, type UidsAndValues, Label, Location, KmsClient, type UidsAndValuesToUpsert, generateAliases } from 'cloudproof_js';
 import { defineComponent } from 'vue';
 import Key from './Key.vue';
 
@@ -251,14 +251,14 @@ export default defineComponent({
         this.users.flatMap((user, index) => {
           return [
             {
-              indexedValue: IndexedValue.fromLocation(new Location(Uint8Array.from([index]))),
-              keywords: new Set([
-                Keyword.fromUtf8String(user.first),
-                Keyword.fromUtf8String(user.last),
-                Keyword.fromUtf8String(user.country),
-                Keyword.fromUtf8String(user.email),
-                Keyword.fromUtf8String(user.project.toString()),
-              ]),
+              indexedValue: Location.fromUtf8String(index.toString()),
+              keywords: [
+                user.first,
+                user.last,
+                user.country,
+                user.email,
+                user.project.toString(),
+              ],
             },
             ...(this.usingGraphs ? [
               // Not required to generate aliases for all fields, you can choose which one you want to alias
@@ -373,10 +373,10 @@ export default defineComponent({
       let keywords = query.split(' ').map((keyword) => keyword.trim()).filter((keyword) => keyword);
       if (keywords.length === 0) return;
 
-      let indexedValues: Array<IndexedValue> | null = null;
+      let locations: Array<Location> | null = null;
       if (this.doOr) {
-        indexedValues = await search(
-          new Set(keywords),
+        locations = await search(
+          keywords,
           this.masterKey,
           FINDEX_LABEL,
           async (uids) => await this.fetchCallback("entries", uids),
@@ -384,20 +384,20 @@ export default defineComponent({
         );
       } else {
         for (const keyword of keywords) {
-          const newIndexedValues = await search(
-            new Set([keyword]),
+          const newLocations = await search(
+            [keyword],
             this.masterKey,
             FINDEX_LABEL,
             async (uids) => await this.fetchCallback("entries", uids),
             async (uids) => await this.fetchCallback("chains", uids),
           );
 
-          if (indexedValues === null) {
-            indexedValues = newIndexedValues;
+          if (locations === null) {
+            locations = newLocations;
           } else {
-            indexedValues = indexedValues.filter((alreadyReturnedIndexedValue) => {
-              for (let newIndexedValue of newIndexedValues) {
-                if (this.uint8ArrayEquals(newIndexedValue.bytes, alreadyReturnedIndexedValue.bytes)) {
+            locations = locations.filter((alreadyReturnedLocations) => {
+              for (let newLocation of newLocations) {
+                if (this.uint8ArrayEquals(newLocation.bytes, alreadyReturnedLocations.bytes)) {
                   return true;
                 }
               }
@@ -408,11 +408,11 @@ export default defineComponent({
         }
       }
 
-      if (indexedValues === null) throw Error("Indexed values cannot be null when a query is provided");
+      if (locations === null) throw Error("Indexed values cannot be null when a query is provided");
 
       let results = [];
-      for (const indexedValue of indexedValues) {
-        const userId = indexedValue.bytes[1];
+      for (const location of locations) {
+        const userId = parseInt(location.toString());
 
         let encryptedUser = this.encryptedUsers[userId];
         this.logRequest({

--- a/examples/vuejs/src/App.vue
+++ b/examples/vuejs/src/App.vue
@@ -251,7 +251,7 @@ export default defineComponent({
         this.users.flatMap((user, index) => {
           return [
             {
-              indexedValue: Location.fromUtf8String(index.toString()),
+              indexedValue: Location.fromString(index.toString()),
               keywords: [
                 user.first,
                 user.last,

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "format": "npm run prettier:fix && npm run lint:fix"
     },
     "dependencies": {
+        "better-sqlite3": "^8.0.1",
         "process": "^0.11.10",
         "stream-browserify": "^3.0.0"
     },
@@ -47,6 +48,7 @@
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-typescript": "^9.0.2",
         "@rollup/plugin-wasm": "^6.0.1",
+        "@types/better-sqlite3": "^7.6.3",
         "@types/node": "^18.7.18",
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.36.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
         "puppeteer": "^19.2.0",
         "redis": "^4.3.1",
         "rollup": "^3.3.0",
-        "sqlite3": "^5.1.2",
         "typescript": "^4.9.0",
         "uuid": "^9.0.0",
         "vitest": "^0.25.2"

--- a/src/findex/findex.ts
+++ b/src/findex/findex.ts
@@ -84,10 +84,6 @@ export class Location {
   }
 
   static fromString(value: string): Location {
-    return Location.fromUtf8String(value)
-  }
-
-  static fromUtf8String(value: string): Location {
     return new Location(new TextEncoder().encode(value))
   }
 
@@ -110,10 +106,6 @@ export class Keyword {
   }
 
   static fromString(value: string): Keyword {
-    return Keyword.fromUtf8String(value)
-  }
-
-  static fromUtf8String(value: string): Keyword {
     return new Keyword(new TextEncoder().encode(value))
   }
 
@@ -155,11 +147,7 @@ export class Label {
   }
 
   static fromString(value: string): Label {
-    return Label.fromUtf8String(value)
-  }
-
-  static fromUtf8String(label: string): Label {
-    return new Label(new TextEncoder().encode(label))
+    return new Label(new TextEncoder().encode(value))
   }
 }
 

--- a/src/findex/findex.ts
+++ b/src/findex/findex.ts
@@ -83,6 +83,10 @@ export class Location {
     this.bytes = bytes
   }
 
+  static fromString(value: string): Location {
+    return Location.fromUtf8String(value)
+  }
+
   static fromUtf8String(value: string): Location {
     return new Location(new TextEncoder().encode(value))
   }
@@ -103,6 +107,10 @@ export class Keyword {
   bytes: Uint8Array
   constructor(bytes: Uint8Array) {
     this.bytes = bytes
+  }
+
+  static fromString(value: string): Keyword {
+    return Keyword.fromUtf8String(value)
   }
 
   static fromUtf8String(value: string): Keyword {
@@ -146,6 +154,10 @@ export class Label {
     }
   }
 
+  static fromString(value: string): Label {
+    return Label.fromUtf8String(value)
+  }
+
   static fromUtf8String(label: string): Label {
     return new Label(new TextEncoder().encode(label))
   }
@@ -186,8 +198,8 @@ export function generateAliases(
       charsIndex === endIndex - 1 ? keyword : keyword.slice(0, charsIndex + 1)
 
     entries.push({
-      indexedValue: IndexedValue.fromNextWord(Keyword.fromUtf8String(to)),
-      keywords: new Set([Keyword.fromUtf8String(from)]),
+      indexedValue: IndexedValue.fromNextWord(Keyword.fromString(to)),
+      keywords: new Set([Keyword.fromString(from)]),
     })
   }
 
@@ -350,7 +362,7 @@ export async function Findex() {
             if (keyword instanceof Keyword) {
               return keyword.bytes
             } else {
-              return Keyword.fromUtf8String(keyword).bytes
+              return Keyword.fromString(keyword).bytes
             }
           }),
         }

--- a/src/findex/in_memory.ts
+++ b/src/findex/in_memory.ts
@@ -1,0 +1,104 @@
+import {
+  FetchChains,
+  FetchEntries,
+  InsertChains,
+  UidsAndValues,
+  UidsAndValuesToUpsert,
+  UpsertEntries,
+} from "./findex"
+
+/**
+ * @returns the callbacks
+ */
+export function callbacksExamplesInMemory(): {
+  fetchEntries: FetchEntries
+  fetchChains: FetchChains
+  upsertEntries: UpsertEntries
+  insertChains: InsertChains
+} {
+  const entries: UidsAndValues = []
+  const chains: UidsAndValues = []
+
+  const fetchCallback = async (
+    table: UidsAndValues,
+    uids: Uint8Array[],
+  ): Promise<UidsAndValues> => {
+    const results: UidsAndValues = []
+    for (const requestedUid of uids) {
+      for (const { uid, value } of table) {
+        if (bytesEquals(uid, requestedUid)) {
+          results.push({ uid, value })
+          break
+        }
+      }
+    }
+    return results
+  }
+  const upsertEntries = async (
+    uidsAndValues: UidsAndValuesToUpsert,
+  ): Promise<UidsAndValues> => {
+    const rejected = [] as UidsAndValues
+    uidsAndValuesLoop: for (const {
+      uid: newUid,
+      oldValue,
+      newValue,
+    } of uidsAndValues) {
+      for (const tableEntry of entries) {
+        if (bytesEquals(tableEntry.uid, newUid)) {
+          if (bytesEquals(tableEntry.value, oldValue)) {
+            tableEntry.value = newValue
+          } else {
+            rejected.push(tableEntry)
+          }
+          continue uidsAndValuesLoop
+        }
+      }
+
+      // The uid doesn't exist yet.
+      if (oldValue !== null) {
+        throw new Error(
+          "Rust shouldn't send us an oldValue if the table never contained a value… (except if there is a compact between)",
+        )
+      }
+
+      entries.push({ uid: newUid, value: newValue })
+    }
+
+    return rejected
+  }
+  const insertChains = async (uidsAndValues: UidsAndValues): Promise<void> => {
+    for (const { uid: newUid, value: newValue } of uidsAndValues) {
+      for (const tableEntry of chains) {
+        if (bytesEquals(tableEntry.uid, newUid)) {
+          tableEntry.value = newValue
+          break
+        }
+      }
+
+      // The uid doesn't exist yet.
+      chains.push({ uid: newUid, value: newValue })
+    }
+  }
+
+  return {
+    fetchEntries: async (uids: Uint8Array[]) =>
+      await fetchCallback(entries, uids),
+    fetchChains: async (uids: Uint8Array[]) =>
+      await fetchCallback(chains, uids),
+    upsertEntries,
+    insertChains,
+  }
+}
+
+/**
+ * @param a one Uint8Array
+ * @param b one Uint8Array
+ * @returns is equals
+ */
+function bytesEquals(a: Uint8Array | null, b: Uint8Array | null): boolean {
+  if (a === null && b === null) return true
+  if (a === null) return false
+  if (b === null) return false
+
+  return Buffer.from(a).toString("base64") === Buffer.from(b).toString("base64")
+}

--- a/src/findex/sqlite.ts
+++ b/src/findex/sqlite.ts
@@ -1,0 +1,113 @@
+import { Database, Statement } from "better-sqlite3"
+import {
+  FetchChains,
+  FetchEntries,
+  InsertChains,
+  UidsAndValues,
+  UidsAndValuesToUpsert,
+  UpsertEntries,
+} from "./findex"
+
+/**
+ * @param db the SQLite3 connection
+ * @returns the callbacks
+ */
+export function callbacksExamplesBetterSqlite3(db: Database): {
+  fetchEntries: FetchEntries
+  fetchChains: FetchChains
+  upsertEntries: UpsertEntries
+  insertChains: InsertChains
+} {
+  db.prepare(
+    "CREATE TABLE entries (uid BLOB PRIMARY KEY, value BLOB NOT NULL)",
+  ).run()
+  db.prepare(
+    "CREATE TABLE chains (uid BLOB PRIMARY KEY, value BLOB NOT NULL)",
+  ).run()
+
+  //
+  // Prepare some useful SQL requests on different databases
+  // `prepare` a statement is a costly operation we don't want to do on every line (or in every callback)
+  //
+  const upsertIntoChainsTableStmt = db.prepare(
+    `INSERT OR REPLACE INTO chains (uid, value) VALUES(?, ?)`,
+  )
+  const upsertIntoEntriesTableStmt = db.prepare(
+    `INSERT INTO entries (uid, value) VALUES (?, ?) ON CONFLICT (uid)  DO UPDATE SET value = ? WHERE value = ?`,
+  )
+  const selectOneEntriesTableItemStmt = db.prepare(
+    `SELECT value FROM entries WHERE uid = ?`,
+  )
+
+  // Save some prepare statements inside these objects
+  // These queries have `WHERE IN (?, ?, ?)` so we need multiple prepare
+  // statements for each different number of parameters (but we can reuse them if
+  // two callbacks have the same number of parameters)
+  const fetchMultipleEntriesTableStmt: { [id: number]: Statement } = {}
+  const fetchMultipleChainsTableStmt: { [id: number]: Statement } = {}
+
+  const prepareFetchMultipleQuery = (table: "entries" | "chains", numberOfUids: number): Statement => {
+    let cache;
+    if (table === "entries") {
+      cache = fetchMultipleEntriesTableStmt
+    } else {
+      cache = fetchMultipleChainsTableStmt
+    }
+
+    if (typeof cache[numberOfUids] !== "undefined") {
+      return cache[numberOfUids]
+    }
+
+    const statement = db.prepare(`
+      SELECT uid, value
+      FROM ${table}
+      WHERE uid IN (${Array(numberOfUids).fill("?").join(",")})
+    `)
+
+    cache[numberOfUids] = statement
+    return statement
+  }
+
+  const fetchCallback = async (
+    table: "entries" | "chains",
+    uids: Uint8Array[],
+  ): Promise<UidsAndValues> => {
+    return prepareFetchMultipleQuery(table, uids.length).all(...uids) as UidsAndValues
+  }
+
+  const upsertEntries = async (
+    uidsAndValues: UidsAndValuesToUpsert,
+  ): Promise<UidsAndValues> => {
+    const rejected = []
+    for (const { uid, oldValue, newValue } of uidsAndValues) {
+      const result = upsertIntoEntriesTableStmt.run(
+        uid,
+        newValue,
+        newValue,
+        oldValue,
+      )
+
+      if (result.changes === 0) {
+        const valueInSqlite = selectOneEntriesTableItemStmt.get(uid).value
+        rejected.push({ uid, value: valueInSqlite })
+      }
+    }
+
+    return rejected
+  }
+
+  const insertChains = async (uidsAndValues: UidsAndValues): Promise<void> => {
+    for (const { uid, value } of uidsAndValues) {
+      upsertIntoChainsTableStmt.run(uid, value)
+    }
+  }
+
+  return {
+    fetchEntries: async (uids: Uint8Array[]) =>
+      await fetchCallback("entries", uids),
+    fetchChains: async (uids: Uint8Array[]) =>
+      await fetchCallback("chains", uids),
+    upsertEntries,
+    insertChains,
+  }
+}

--- a/src/findex/sqlite.ts
+++ b/src/findex/sqlite.ts
@@ -46,8 +46,11 @@ export function callbacksExamplesBetterSqlite3(db: Database): {
   const fetchMultipleEntriesTableStmt: { [id: number]: Statement } = {}
   const fetchMultipleChainsTableStmt: { [id: number]: Statement } = {}
 
-  const prepareFetchMultipleQuery = (table: "entries" | "chains", numberOfUids: number): Statement => {
-    let cache;
+  const prepareFetchMultipleQuery = (
+    table: "entries" | "chains",
+    numberOfUids: number,
+  ): Statement => {
+    let cache
     if (table === "entries") {
       cache = fetchMultipleEntriesTableStmt
     } else {
@@ -72,7 +75,9 @@ export function callbacksExamplesBetterSqlite3(db: Database): {
     table: "entries" | "chains",
     uids: Uint8Array[],
   ): Promise<UidsAndValues> => {
-    return prepareFetchMultipleQuery(table, uids.length).all(...uids) as UidsAndValues
+    return prepareFetchMultipleQuery(table, uids.length).all(
+      ...uids,
+    ) as UidsAndValues
   }
 
   const upsertEntries = async (

--- a/tests/findex.bench.ts
+++ b/tests/findex.bench.ts
@@ -31,8 +31,8 @@ describe("Findex Upsert", async () => {
       newIndexedEntries.push({
         indexedValue: IndexedValue.fromLocation(Location.fromUuid(user.id)),
         keywords: new Set([
-          Keyword.fromUtf8String(user.firstName),
-          Keyword.fromUtf8String(user.country),
+          Keyword.fromString(user.firstName),
+          Keyword.fromString(user.country),
         ]),
       })
     }
@@ -55,8 +55,8 @@ describe("Findex Upsert", async () => {
       newIndexedEntries.push({
         indexedValue: IndexedValue.fromLocation(Location.fromUuid(user.id)),
         keywords: new Set([
-          Keyword.fromUtf8String(user.firstName),
-          Keyword.fromUtf8String(user.country),
+          Keyword.fromString(user.firstName),
+          Keyword.fromString(user.country),
         ]),
       })
     }
@@ -80,8 +80,8 @@ describe("Findex Search", async () => {
     newIndexedEntries.push({
       indexedValue: IndexedValue.fromLocation(Location.fromUuid(user.id)),
       keywords: new Set([
-        Keyword.fromUtf8String(user.firstName),
-        Keyword.fromUtf8String(user.country),
+        Keyword.fromString(user.firstName),
+        Keyword.fromString(user.country),
       ]),
     })
   }

--- a/tests/findex.test.ts
+++ b/tests/findex.test.ts
@@ -15,131 +15,14 @@ import {
   LocationIndexEntry,
   KeywordIndexEntry,
   generateAliases,
+  callbacksExamplesBetterSqlite3,
 } from ".."
 import { USERS } from "./data/users"
 import { expect, test } from "vitest"
 import { createClient, defineScript } from "redis"
 import { hexEncode } from "../src/utils/utils"
 import { randomBytes } from "crypto"
-import sqlite3 from "sqlite3"
-
-test("upsert and search memory", async () => {
-  const findex = await Findex()
-
-  const entryLocation: IndexedEntry = {
-    indexedValue: IndexedValue.fromLocation(
-      Location.fromUtf8String("ROBERT file"),
-    ),
-    keywords: new Set([Keyword.fromUtf8String("ROBERT")]),
-  }
-  const entryLocation_ = new LocationIndexEntry("ROBERT file", ["ROBERT"])
-  expect(entryLocation_).toEqual(entryLocation)
-
-  const arrayLocation: IndexedEntry = {
-    indexedValue: IndexedValue.fromLocation(
-      Location.fromUtf8String("ROBERT file array"),
-    ),
-    keywords: new Set([Keyword.fromUtf8String("ROBERT")]),
-  }
-  const arrayLocation_ = new LocationIndexEntry("ROBERT file array", [
-    new TextEncoder().encode("ROBERT"),
-  ])
-  expect(arrayLocation_).toEqual(arrayLocation)
-
-  const entryKeyword: IndexedEntry = {
-    indexedValue: IndexedValue.fromNextWord(Keyword.fromUtf8String("ROBERT")),
-    keywords: new Set([Keyword.fromUtf8String("BOB")]),
-  }
-  const entryKeyword_ = new KeywordIndexEntry("BOB", "ROBERT")
-  expect(entryKeyword_).toEqual(entryKeyword)
-
-  const masterKey = new FindexKey(randomBytes(32))
-
-  const label = new Label("test")
-
-  const entryTable: { [uid: string]: Uint8Array } = {}
-  const chainTable: { [uid: string]: Uint8Array } = {}
-
-  const fetchEntries: FetchEntries = async (
-    uids: Uint8Array[],
-  ): Promise<UidsAndValues> => {
-    const results: UidsAndValues = []
-    for (const uid of uids) {
-      const value = entryTable[hexEncode(uid)]
-      if (typeof value !== "undefined") {
-        results.push({ uid, value })
-      }
-    }
-    return await Promise.resolve(results)
-  }
-
-  const fetchChains: FetchChains = async (
-    uids: Uint8Array[],
-  ): Promise<UidsAndValues> => {
-    const results: UidsAndValues = []
-    for (const uid of uids) {
-      const value = chainTable[hexEncode(uid)]
-      if (typeof value !== "undefined") {
-        results.push({ uid, value })
-      }
-    }
-    return await Promise.resolve(results)
-  }
-
-  const upsertEntries: UpsertEntries = async (
-    uidsAndValues: UidsAndValuesToUpsert,
-  ): Promise<UidsAndValues> => {
-    for (const { uid, newValue } of uidsAndValues) {
-      entryTable[hexEncode(uid)] = newValue
-    }
-    return await Promise.resolve([])
-  }
-
-  const insertChains: InsertChains = async (
-    uidsAndValues: UidsAndValues,
-  ): Promise<void> => {
-    for (const { uid, value } of uidsAndValues) {
-      chainTable[hexEncode(uid)] = value
-    }
-    return await Promise.resolve()
-  }
-
-  await findex.upsert(
-    [entryLocation, entryKeyword, arrayLocation],
-    masterKey,
-    label,
-    fetchEntries,
-    upsertEntries,
-    insertChains,
-  )
-
-  const results0 = await findex.search(
-    new Set(["ROBERT"]),
-    masterKey,
-    label,
-    fetchEntries,
-    fetchChains,
-  )
-  expect(results0.length).toEqual(2)
-
-  const results1 = await findex.search(
-    new Set([new TextEncoder().encode("ROBERT")]),
-    masterKey,
-    label,
-    fetchEntries,
-    fetchChains,
-  )
-  expect(results1.length).toEqual(2)
-
-  const results2 = await findex.search(
-    new Set(["BOB"]),
-    masterKey,
-    label,
-    fetchEntries,
-    fetchChains,
-  )
-  expect(results2.length).toEqual(2)
-})
+import Database from "better-sqlite3"
 
 test("in memory", async () => {
   const entryTable: UidsAndValues = []
@@ -218,106 +101,16 @@ test("in memory", async () => {
   )
 })
 
-test("SQLite", async () => {
-  const db = new sqlite3.Database(":memory:")
-  await new Promise((resolve) => {
-    db.run(
-      "CREATE TABLE entry_table (uid BYTES PRIMARY KEY, value BYTES)",
-      resolve,
-    )
-  })
-  await new Promise((resolve) => {
-    db.run(
-      "CREATE TABLE chain_table (uid BYTES PRIMARY KEY, value BYTES)",
-      resolve,
-    )
-  })
+test.only("SQLite", async () => {
+  const db = new Database(":memory:")
 
-  const fetchCallback = async (
-    table: string,
-    uids: Uint8Array[],
-  ): Promise<UidsAndValues> => {
-    return await new Promise((resolve, reject) => {
-      db.all(
-        `SELECT uid, value FROM ${table} WHERE uid IN (${uids
-          .map(() => "?")
-          .join(",")})`,
-        uids,
-        (err: any, rows: UidsAndValues) => {
-          if (err !== null && typeof err !== "undefined") reject(err)
-          resolve(rows)
-        },
-      )
-    })
-  }
-  const insertCallback = async (
-    table: string,
-    uidsAndValues: UidsAndValues,
-  ): Promise<void> => {
-    for (const { uid, value } of uidsAndValues) {
-      await new Promise((resolve, reject) => {
-        db.run(
-          `INSERT OR REPLACE INTO ${table} (uid, value) VALUES(?, ?)`,
-          [uid, value],
-          (err: any) => {
-            if (err !== null && typeof err !== "undefined") reject(err)
-            resolve(null)
-          },
-        )
-      })
-    }
-  }
-  const upsertCallback = async (
-    table: string,
-    uidsAndValues: UidsAndValuesToUpsert,
-  ): Promise<UidsAndValues> => {
-    const rejected = [] as UidsAndValues
-    await Promise.all(
-      uidsAndValues.map(async ({ uid, oldValue, newValue }) => {
-        const changed: boolean = await new Promise((resolve, reject) => {
-          db.run(
-            `INSERT INTO ${table} (uid, value) VALUES (?, ?)  ON CONFLICT (uid)  DO UPDATE SET value = ? WHERE value = ?`,
-            [uid, newValue, newValue, oldValue],
-            function (err: any) {
-              if (err !== null && typeof err !== "undefined") {
-                reject(err)
-              } else {
-                resolve(this.changes === 1)
-              }
-            },
-          )
-        })
-
-        if (!changed) {
-          const valueInSqlite: Uint8Array = await new Promise(
-            (resolve, reject) => {
-              db.get(
-                `SELECT value FROM ${table} WHERE uid = ?`,
-                [uid],
-                (err: any, row: { value: Uint8Array }) => {
-                  if (err !== null && typeof err !== "undefined") {
-                    reject(err)
-                  } else {
-                    resolve(row.value)
-                  }
-                },
-              )
-            },
-          )
-
-          rejected.push({ uid, value: valueInSqlite })
-        }
-      }),
-    )
-
-    return rejected
-  }
+  const callbacks = callbacksExamplesBetterSqlite3(db);
 
   await run(
-    async (uids) => await fetchCallback("entry_table", uids),
-    async (uids) => await fetchCallback("chain_table", uids),
-    async (uidsAndValues) => await upsertCallback("entry_table", uidsAndValues),
-    async (uidsAndValues) => await insertCallback("chain_table", uidsAndValues),
+    callbacks.fetchEntries,
+    callbacks.fetchChains,
+    callbacks.upsertEntries,
+    callbacks.insertChains,
   )
 })
 
@@ -444,11 +237,8 @@ async function run(
     const newIndexedEntries: IndexedEntry[] = []
     for (const user of USERS) {
       newIndexedEntries.push({
-        indexedValue: IndexedValue.fromLocation(Location.fromUuid(user.id)),
-        keywords: new Set([
-          Keyword.fromUtf8String(user.firstName),
-          Keyword.fromUtf8String(user.country),
-        ]),
+        indexedValue: Location.fromUuid(user.id),
+        keywords: [user.firstName, user.country],
       })
     }
 
@@ -461,25 +251,39 @@ async function run(
       insertChains,
     )
 
-    const results = await findex.search(
-      new Set([USERS[0].firstName]),
-      masterKey,
-      label,
-      fetchEntries,
-      fetchChains,
-    )
+    {
+      const results = await findex.rawSearch(
+        [USERS[0].firstName],
+        masterKey,
+        label,
+        fetchEntries,
+        fetchChains,
+      )
 
-    expect(results.length).toEqual(1)
-    expect(results[0]).toEqual(
-      IndexedValue.fromLocation(Location.fromUuid(USERS[0].id)),
-    )
+      expect(results.length).toEqual(1)
+      expect(results[0]).toEqual(
+        IndexedValue.fromLocation(Location.fromUuid(USERS[0].id)),
+      )
+    }
+    {
+      const results = await findex.search(
+        [USERS[0].firstName],
+        masterKey,
+        label,
+        fetchEntries,
+        fetchChains,
+      )
+
+      expect(results.length).toEqual(1)
+      expect(results[0]).toEqual(Location.fromUuid(USERS[0].id))
+    }
   }
 
   {
     // Test with multiple results.
 
-    const results = await findex.search(
-      new Set(["Spain"]),
+    const results = await findex.rawSearch(
+      ["Spain"],
       masterKey,
       label,
       fetchEntries,
@@ -494,10 +298,8 @@ async function run(
     await findex.upsert(
       [
         {
-          indexedValue: IndexedValue.fromNextWord(
-            Keyword.fromUtf8String(USERS[0].firstName),
-          ),
-          keywords: new Set([Keyword.fromUtf8String("SomeAlias")]),
+          indexedValue: Keyword.fromUtf8String(USERS[0].firstName),
+          keywords: ["SomeAlias"],
         },
         ...generateAliases("SomeAlias"),
       ],
@@ -509,18 +311,32 @@ async function run(
     )
 
     const searchAndCheck = async (keyword: string): Promise<void> => {
-      const results = await findex.search(
-        new Set([keyword]),
-        masterKey,
-        label,
-        fetchEntries,
-        fetchChains,
-      )
+      {
+        const results = await findex.rawSearch(
+          [keyword],
+          masterKey,
+          label,
+          fetchEntries,
+          fetchChains,
+        )
 
-      expect(results.length).toEqual(1)
-      expect(results[0]).toEqual(
-        IndexedValue.fromLocation(Location.fromUuid(USERS[0].id)),
-      )
+        expect(results.length).toEqual(1)
+        expect(results[0]).toEqual(
+          IndexedValue.fromLocation(Location.fromUuid(USERS[0].id)),
+        )
+      }
+      {
+        const results = await findex.search(
+          new Set([keyword]),
+          masterKey,
+          label,
+          fetchEntries,
+          fetchChains,
+        )
+
+        expect(results.length).toEqual(1)
+        expect(results[0]).toEqual(Location.fromUuid(USERS[0].id))
+      }
     }
 
     await searchAndCheck("Som")
@@ -538,10 +354,8 @@ async function run(
         return findex.upsert(
           [
             {
-              indexedValue: IndexedValue.fromLocation(
-                Location.fromUtf8String(index.toString()),
-              ),
-              keywords: new Set([Keyword.fromUtf8String("Concurrent")]),
+              indexedValue: Location.fromUtf8String(index.toString()),
+              keywords: ["Concurrent"],
             },
           ],
           masterKey,
@@ -553,8 +367,8 @@ async function run(
       }),
     )
 
-    const results = await findex.search(
-      new Set(["Concurrent"]),
+    const results = await findex.rawSearch(
+      ["Concurrent"],
       masterKey,
       label,
       fetchEntries,
@@ -602,6 +416,124 @@ test("generateAliases", async () => {
     checkAlias(aliases[1], "Thib", "Thiba")
     checkAlias(aliases[2], "Thiba", "Thibaud")
   }
+})
+
+test("upsert and search memory", async () => {
+  const findex = await Findex()
+
+  const entryLocation: IndexedEntry = {
+    indexedValue: IndexedValue.fromLocation(
+      Location.fromUtf8String("ROBERT file"),
+    ),
+    keywords: new Set([Keyword.fromUtf8String("ROBERT")]),
+  }
+  const entryLocation_ = new LocationIndexEntry("ROBERT file", ["ROBERT"])
+  expect(entryLocation_).toEqual(entryLocation)
+
+  const arrayLocation: IndexedEntry = {
+    indexedValue: IndexedValue.fromLocation(
+      Location.fromUtf8String("ROBERT file array"),
+    ),
+    keywords: new Set([Keyword.fromUtf8String("ROBERT")]),
+  }
+  const arrayLocation_ = new LocationIndexEntry("ROBERT file array", [
+    new TextEncoder().encode("ROBERT"),
+  ])
+  expect(arrayLocation_).toEqual(arrayLocation)
+
+  const entryKeyword: IndexedEntry = {
+    indexedValue: IndexedValue.fromNextWord(Keyword.fromUtf8String("ROBERT")),
+    keywords: new Set([Keyword.fromUtf8String("BOB")]),
+  }
+  const entryKeyword_ = new KeywordIndexEntry("BOB", "ROBERT")
+  expect(entryKeyword_).toEqual(entryKeyword)
+
+  const masterKey = new FindexKey(randomBytes(32))
+
+  const label = new Label("test")
+
+  const entryTable: { [uid: string]: Uint8Array } = {}
+  const chainTable: { [uid: string]: Uint8Array } = {}
+
+  const fetchEntries: FetchEntries = async (
+    uids: Uint8Array[],
+  ): Promise<UidsAndValues> => {
+    const results: UidsAndValues = []
+    for (const uid of uids) {
+      const value = entryTable[hexEncode(uid)]
+      if (typeof value !== "undefined") {
+        results.push({ uid, value })
+      }
+    }
+    return await Promise.resolve(results)
+  }
+
+  const fetchChains: FetchChains = async (
+    uids: Uint8Array[],
+  ): Promise<UidsAndValues> => {
+    const results: UidsAndValues = []
+    for (const uid of uids) {
+      const value = chainTable[hexEncode(uid)]
+      if (typeof value !== "undefined") {
+        results.push({ uid, value })
+      }
+    }
+    return await Promise.resolve(results)
+  }
+
+  const upsertEntries: UpsertEntries = async (
+    uidsAndValues: UidsAndValuesToUpsert,
+  ): Promise<UidsAndValues> => {
+    for (const { uid, newValue } of uidsAndValues) {
+      entryTable[hexEncode(uid)] = newValue
+    }
+    return await Promise.resolve([])
+  }
+
+  const insertChains: InsertChains = async (
+    uidsAndValues: UidsAndValues,
+  ): Promise<void> => {
+    for (const { uid, value } of uidsAndValues) {
+      chainTable[hexEncode(uid)] = value
+    }
+    return await Promise.resolve()
+  }
+
+  await findex.upsert(
+    [entryLocation, entryKeyword, arrayLocation],
+    masterKey,
+    label,
+    fetchEntries,
+    upsertEntries,
+    insertChains,
+  )
+
+  const results0 = await findex.rawSearch(
+    new Set(["ROBERT"]),
+    masterKey,
+    label,
+    fetchEntries,
+    fetchChains,
+  )
+  expect(results0.length).toEqual(2)
+
+  const results1 = await findex.rawSearch(
+    new Set([new TextEncoder().encode("ROBERT")]),
+    masterKey,
+    label,
+    fetchEntries,
+    fetchChains,
+  )
+  expect(results1.length).toEqual(2)
+
+  const results2 = await findex.rawSearch(
+    new Set(["BOB"]),
+    masterKey,
+    label,
+    fetchEntries,
+    fetchChains,
+  )
+  expect(results2.length).toEqual(2)
 })
 
 /**

--- a/tests/findex.test.ts
+++ b/tests/findex.test.ts
@@ -35,7 +35,7 @@ test("in memory", async () => {
   )
 })
 
-test.only("SQLite", async () => {
+test("SQLite", async () => {
   const db = new Database(":memory:")
 
   const callbacks = callbacksExamplesBetterSqlite3(db)

--- a/tests/findex.test.ts
+++ b/tests/findex.test.ts
@@ -281,26 +281,27 @@ async function run(
     await searchAndCheck("SomeAlia")
   }
 
-  {
-    await Promise.all(
-      // eslint-disable-next-line @typescript-eslint/promise-function-async
-      Array.from(Array(100).keys()).map((index) => {
-        return findex.upsert(
-          [
-            {
-              indexedValue: Location.fromString(index.toString()),
-              keywords: ["Concurrent"],
-            },
-          ],
-          masterKey,
-          label,
-          fetchEntries,
-          upsertEntries,
-          insertChains,
-        )
-      }),
-    )
+  const sourceIds = Array.from(Array(100).keys()).map((id) => id * id)
 
+  await Promise.all(
+    // eslint-disable-next-line @typescript-eslint/promise-function-async
+    sourceIds.map((id) => {
+      return findex.upsert(
+        [
+          {
+            indexedValue: Location.fromNumber(id),
+            keywords: ["Concurrent"],
+          },
+        ],
+        masterKey,
+        label,
+        fetchEntries,
+        upsertEntries,
+        insertChains,
+      )
+    }),
+  )
+  {
     const results = await findex.rawSearch(
       ["Concurrent"],
       masterKey,
@@ -310,6 +311,22 @@ async function run(
     )
 
     expect(results.length).toEqual(100)
+  }
+
+  {
+    const results = await findex.search(
+      ["Concurrent"],
+      masterKey,
+      label,
+      fetchEntries,
+      fetchChains,
+    )
+
+    expect(results.length).toEqual(100)
+    const resultsIds = results
+      .map((location) => location.toNumber())
+      .sort((a, b) => a - b)
+    expect(resultsIds).toEqual(sourceIds)
   }
 }
 

--- a/tests/findex.test.ts
+++ b/tests/findex.test.ts
@@ -232,7 +232,7 @@ async function run(
     await findex.upsert(
       [
         {
-          indexedValue: Keyword.fromUtf8String(USERS[0].firstName),
+          indexedValue: Keyword.fromString(USERS[0].firstName),
           keywords: ["SomeAlias"],
         },
         ...generateAliases("SomeAlias"),
@@ -288,7 +288,7 @@ async function run(
         return findex.upsert(
           [
             {
-              indexedValue: Location.fromUtf8String(index.toString()),
+              indexedValue: Location.fromString(index.toString()),
               keywords: ["Concurrent"],
             },
           ],
@@ -316,9 +316,9 @@ async function run(
 test("generateAliases", async () => {
   const checkAlias = (alias: IndexedEntry, from: string, to: string): void => {
     expect(alias.indexedValue).toEqual(
-      IndexedValue.fromNextWord(Keyword.fromUtf8String(to)),
+      IndexedValue.fromNextWord(Keyword.fromString(to)),
     )
-    expect(alias.keywords).toEqual(new Set([Keyword.fromUtf8String(from)]))
+    expect(alias.keywords).toEqual(new Set([Keyword.fromString(from)]))
   }
 
   {
@@ -357,18 +357,18 @@ test("upsert and search memory", async () => {
 
   const entryLocation: IndexedEntry = {
     indexedValue: IndexedValue.fromLocation(
-      Location.fromUtf8String("ROBERT file"),
+      Location.fromString("ROBERT file"),
     ),
-    keywords: new Set([Keyword.fromUtf8String("ROBERT")]),
+    keywords: new Set([Keyword.fromString("ROBERT")]),
   }
   const entryLocation_ = new LocationIndexEntry("ROBERT file", ["ROBERT"])
   expect(entryLocation_).toEqual(entryLocation)
 
   const arrayLocation: IndexedEntry = {
     indexedValue: IndexedValue.fromLocation(
-      Location.fromUtf8String("ROBERT file array"),
+      Location.fromString("ROBERT file array"),
     ),
-    keywords: new Set([Keyword.fromUtf8String("ROBERT")]),
+    keywords: new Set([Keyword.fromString("ROBERT")]),
   }
   const arrayLocation_ = new LocationIndexEntry("ROBERT file array", [
     new TextEncoder().encode("ROBERT"),
@@ -376,8 +376,8 @@ test("upsert and search memory", async () => {
   expect(arrayLocation_).toEqual(arrayLocation)
 
   const entryKeyword: IndexedEntry = {
-    indexedValue: IndexedValue.fromNextWord(Keyword.fromUtf8String("ROBERT")),
-    keywords: new Set([Keyword.fromUtf8String("BOB")]),
+    indexedValue: IndexedValue.fromNextWord(Keyword.fromString("ROBERT")),
+    keywords: new Set([Keyword.fromString("BOB")]),
   }
   const entryKeyword_ = new KeywordIndexEntry("BOB", "ROBERT")
   expect(entryKeyword_).toEqual(entryKeyword)

--- a/tests/findex.test.ts
+++ b/tests/findex.test.ts
@@ -356,9 +356,7 @@ test("upsert and search memory", async () => {
   const findex = await Findex()
 
   const entryLocation: IndexedEntry = {
-    indexedValue: IndexedValue.fromLocation(
-      Location.fromString("ROBERT file"),
-    ),
+    indexedValue: IndexedValue.fromLocation(Location.fromString("ROBERT file")),
     keywords: new Set([Keyword.fromString("ROBERT")]),
   }
   const entryLocation_ = new LocationIndexEntry("ROBERT file", ["ROBERT"])


### PR DESCRIPTION
- Allow passing `Array` instead of `Set`
- Allow passing `string` instead of `Keyword` where unambiguous
- Allow passing `Location | Keyword` instead of `IndexedValue`
- `search` is now returning only `Location` object (not `IndexedValue` anymore and `rawSearch` is returning the full result)
- `Location` objects can be converted to strings (raw string or UUID string)

---

- Split IMDB example in two files, one with all the stats and one without.

---

- Add SQLite3 examples callbacks in lib
- Add in memory examples callbacks in lib